### PR TITLE
:bug: Fix Docker CMD to include host option for Vite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ COPY . .
 EXPOSE 5173
 
 # Comando por defecto para iniciar Vite
-CMD ["npm", "run", "dev"]
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/README.md
+++ b/README.md
@@ -10,3 +10,20 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Docker Usage
+
+### Build the Docker image
+```zsh
+docker build -t promar-app .
+```
+
+### Run the Docker container
+```zsh
+docker run -d -p 5173:5173 --name promar-app-container promar-app
+```
+
+### Test the app with curl
+```zsh
+curl -I http://localhost:5173
+```


### PR DESCRIPTION
This pull request makes updates to the `Dockerfile` to enhance the development server's accessibility and adds a new section in the `README.md` to provide Docker usage instructions. These changes aim to improve the developer experience and make it easier to build and run the application in a Dockerized environment.

### Docker-related changes:

* **Enhanced Vite development server accessibility**: Updated the `CMD` instruction in the `Dockerfile` to include the `--host` flag, allowing the Vite development server to be accessible from outside the container. (`Dockerfile`, [DockerfileL20-R20](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L20-R20))

* **Added Docker usage instructions**: Introduced a new section in the `README.md` with detailed steps on how to build the Docker image, run the container, and test the application using `curl`. (`README.md`, [README.mdR13-R29](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R13-R29))